### PR TITLE
Handling of thick elements other than Drift

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -91,3 +91,16 @@ def test_line():
     line.remove_zero_length_drifts(inplace=True)
     n_elements -= n_zerolength_drifts
     assert len(line) == n_elements
+
+
+def test_thick():
+    dummy_thick_mult = xline.Multipole(knl=[0, -1.], ksl=[0,0], length=4)
+    dummy_thick_mult.isthick = True
+
+    line = xline.Line(elements=[xline.Drift(length=1.),
+                                xline.Multipole(knl=[0, 1.], ksl=[0,0]),
+                                xline.Drift(length=3),
+                                dummy_thick_mult])
+
+    assert np.isclose(line.get_length(), 8.0, rtol=1.e-30, atol=1.e-20)
+

--- a/xline/line.py
+++ b/xline/line.py
@@ -12,6 +12,14 @@ from .closed_orbit import healy_symplectify
 from .linear_normal_form import _linear_normal_form
 
 
+
+_thick_element_types = (elements.Drift, elements.DriftExact)
+
+def _is_thick(element):
+    return  ((hasattr(element, "isthick") and element.isthick) or
+             (isinstance(element, _thick_element_types)))
+
+
 # missing access to particles._m:
 deg2rad = np.pi / 180.
 
@@ -119,12 +127,12 @@ class Line(Element):
 
         ll = 0
         for ee in self.elements:
-            if isinstance(ee, thick_element_types):
+            if _is_thick(ee):
                 ll += ee.length
+
         return ll
 
     def get_s_elements(self, mode="upstream"):
-        thick_element_types = (elements.Drift, elements.DriftExact)
 
         assert mode in ["upstream", "downstream"]
         s_prev = 0
@@ -132,7 +140,7 @@ class Line(Element):
         for ee in self.elements:
             if mode == "upstream":
                 s.append(s_prev)
-            if isinstance(ee, thick_element_types):
+            if _is_thick(ee):
                 s_prev += ee.length
             if mode == "downstream":
                 s.append(s_prev)

--- a/xline/line.py
+++ b/xline/line.py
@@ -23,9 +23,19 @@ class Line(Element):
     ]
     _extra = []
 
+    def __init__(self, elements=(), element_names=None):
+        self.elements = elements
+        if element_names is None:
+            element_names = [ f"e{ii}" for ii in range(len(elements))]
+
+        self.element_names = element_names
+
+        assert len(self.elements) == len(self.element_names)
+
     def __len__(self):
         assert len(self.elements) == len(self.element_names)
         return len(self.elements)
+
 
     def to_dict(self, keepextra=True):
         out = {}


### PR DESCRIPTION
Introduced a new optional attribute for elements- isthick. If this is present and true, the length of the element is treated like that of drift when computing quantities like the machine length. In addition, a constructor is added for Line that performs validity checks and assigns default element names if none were supplied. 